### PR TITLE
add user credentials for mqtt access

### DIFF
--- a/action-Datum_und_Uhrzeit.py
+++ b/action-Datum_und_Uhrzeit.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-from hermes_python.hermes import Hermes
 import datetime
+from hermes_python.hermes import Hermes, MqttOptions
+import toml
 
 
 USERNAME_INTENTS = "domi"
@@ -67,5 +68,12 @@ def subscribe_intent_callback(hermes, intent_message):
 
 
 if __name__ == "__main__":
-    with Hermes("localhost:1883") as h:
+    config = toml.load('/etc/snips.toml')
+
+    broker_address = config['snips-common']['mqtt']
+    mqtt_username = config['snips-common']['mqtt_username']
+    mqtt_password = config['snips-common']['mqtt_password']
+
+    mqtt_opts = MqttOptions(username=mqtt_username, password=mqtt_password, broker_address=broker_address)
+    with Hermes(mqtt_options=mqtt_opts) as h:
         h.subscribe_intents(subscribe_intent_callback).start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-# Bindings for the hermes protocol 
-hermes-python>=0.1
-
+# Bindings for the hermes protocol
+hermes-python>=0.5.2
+toml>=0.10.0


### PR DESCRIPTION
At the moment custom mqtt setups are not supported. With this commit the default snips credentials are used for login.